### PR TITLE
Fix Next.js version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Next.js & NextUI Template
 
-This is a template for creating applications using Next.js 14 (app directory) and NextUI (v2).
+This is a template for creating applications using Next.js 15 (app directory) and NextUI (v2).
 
 [Try it on CodeSandbox](https://githubbox.com/nextui-org/next-app-template)
 
 ## Technologies Used
 
-- [Next.js 14](https://nextjs.org/docs/getting-started)
+- [Next.js 15](https://nextjs.org/docs/getting-started)
 - [NextUI v2](https://nextui.org/)
 - [Tailwind CSS](https://tailwindcss.com/)
 - [Tailwind Variants](https://tailwind-variants.org)


### PR DESCRIPTION
## Summary
- update README to reference Next.js 15 instead of Next.js 14

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b3e58e780832d8139554aab3cfd4f