### PR TITLE
Fix clerk webhook typos

### DIFF
--- a/app/api/webhooks/clerk/route.ts
+++ b/app/api/webhooks/clerk/route.ts
@@ -21,7 +21,7 @@ export async function POST(req: Request) {
 
   // If there are no headers, error out
   if (!svix_id || !svix_timestamp || !svix_signature) {
-    return new Response('Error occured -- no svix headers', {
+    return new Response('Error occurred -- no svix headers', {
       status: 400,
     })
   }
@@ -44,7 +44,7 @@ export async function POST(req: Request) {
     }) as WebhookEvent
   } catch (err) {
     console.error('Error verifying webhook:', err)
-    return new Response('Error occured', {
+    return new Response('Error occurred', {
       status: 400,
     })
   }


### PR DESCRIPTION
## Summary
- fix typo in clerk webhook route

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: prisma binaries download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684b3e2f3534832d897126bab2cf70cf